### PR TITLE
implement miner unregister instruction

### DIFF
--- a/program/src/instruction/mine/miner_unregister.rs
+++ b/program/src/instruction/mine/miner_unregister.rs
@@ -1,5 +1,50 @@
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
+use crate::state::utils::try_from_account_info;
+use crate::state::miner::Miner;
 
-pub fn process_unregister(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+pub fn process_unregister(accounts: &[AccountInfo], _data: &[u8]) -> ProgramResult {
+    let [
+        signer_info,
+        miner_info,
+        _system_program_info
+    ] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys)
+    };
+
+    if !signer_info.is_signer(){
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if !miner_info.is_writable() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // todo : miner_info must be owned by tape_api::ID
+
+    let miner = unsafe {
+        try_from_account_info::<Miner>(miner_info)?
+    };
+
+    if miner.authority != *signer_info.key(){
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    if miner.unclaimed_rewards != 0 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let amount = miner_info.lamports();
+    {
+        let mut signer_lamports = signer_info.try_borrow_mut_lamports()?;
+        *signer_lamports = signer_lamports.saturating_add(amount);
+    }
+
+    {
+        let mut miner_lamports = miner_info.try_borrow_mut_lamports()?;
+        *miner_lamports = 0;
+    }
+
+    miner_info.close()?;
+
     Ok(())
 }

--- a/program/src/state/miner.rs
+++ b/program/src/state/miner.rs
@@ -1,0 +1,25 @@
+use pinocchio::{pubkey::Pubkey};
+use crate::state::utils::DataLen;
+
+#[repr(C)]
+pub struct Miner {
+    pub authority: Pubkey,
+
+    pub name: [u8; 32],
+    pub unclaimed_rewards: u64,
+
+    pub challenge: [u8; 32],
+    pub commitment: [u8; 32],
+
+    pub multiplier: u64,
+
+    pub last_proof_block: u64,
+    pub last_proof_at: i64,
+
+    pub total_proofs: u64,
+    pub total_rewards: u64,
+}
+
+impl DataLen for Miner {
+    const LEN: usize = core::mem::size_of::<Miner>();
+}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod constant;
 pub mod my_state;
 pub mod utils;
+pub mod miner;
 
 pub use constant::*;
 pub use my_state::*;
 pub use utils::*;
+pub use miner::*;


### PR DESCRIPTION
Changes :
- implemented `process_unregister` for miner

Checks implemented : 
- verify signer authority
- check unclaimed rewards
- transfer lamports back to signer
- close the miner account
