### PR TITLE
feat: add instruction structs (Write, Update, Finalize, SetHeader, Su…

### DIFF
--- a/program/src/instruction/mod.rs
+++ b/program/src/instruction/mod.rs
@@ -10,7 +10,10 @@ pub mod mine;
 pub mod spool;
 pub mod tape;
 
-pub use {init::*, mine::*, spool::*, tape::*};
+pub use init::*;
+pub use mine::*;
+pub use spool::*;
+pub use tape::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]

--- a/program/src/instruction/mod.rs
+++ b/program/src/instruction/mod.rs
@@ -1,14 +1,53 @@
-use pinocchio::program_error::ProgramError;
+use {
+    bytemuck::{Pod, Zeroable},
+    pinocchio::program_error::ProgramError,
+    tape_api::consts::{HEADER_SIZE, NAME_LEN, SEGMENT_SIZE},
+    tape_api::types::ProofPath,
+};
 
 pub mod init;
 pub mod mine;
 pub mod spool;
 pub mod tape;
 
-pub use init::*;
-pub use mine::*;
-pub use spool::*;
-pub use tape::*;
+pub use {init::*, mine::*, spool::*, tape::*};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct Create {
+    pub name: [u8; NAME_LEN],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct Write {
+    // Phantom Vec<u8> to ensure the size is dynamic
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct Update {
+    pub segment_number: [u8; 8],
+    pub old_data: [u8; SEGMENT_SIZE],
+    pub new_data: [u8; SEGMENT_SIZE],
+    pub proof: ProofPath,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct Finalize {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct SetHeader {
+    pub header: [u8; HEADER_SIZE],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct Subsidize {
+    pub amount: [u8; 8],
+}
 
 #[repr(u8)]
 pub enum TapeInstruction {


### PR DESCRIPTION
### What’s new

- Added instruction struct definitions:  
  - `Create`  
  - `Write`  
  - `Update`  
  - `Finalize`  
  - `SetHeader`  
  - `Subsidize`  
  
  ### Notes
  - These will only be used to deserialize instruction data for their appropriate instruction's expected layouts.