### PR TITLE
feat: implement tape_create and tape_set_header, resolve MerkleTree imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "pinocchio-system",
  "pinocchio-token",
  "shank",
+ "utils",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,6 +15,9 @@ documentation = "https://docs.rs/tape-api"
 crate-type = ["rlib"]
 
 [dependencies]
+# Local dependencies
+utils = { path = "../utils" }
+
 # Workspace dependencies
 bytemuck.workspace = true
 num_enum.workspace = true

--- a/api/src/state/spool.rs
+++ b/api/src/state/spool.rs
@@ -10,7 +10,7 @@ pub struct Spool {
     pub number: u64,
 
     pub authority: Pubkey,
-    // pub state: TapeTree,
+    pub state: TapeTree,
     pub seed: [u8; 32],
     pub contains: [u8; 32],
 

--- a/api/src/state/writer.rs
+++ b/api/src/state/writer.rs
@@ -1,4 +1,5 @@
 use crate::state::utils::{load_acc, load_acc_mut, DataLen, Initialized};
+use crate::types::SegmentTree;
 
 use bytemuck::{Pod, Zeroable};
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
@@ -7,7 +8,7 @@ use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct Writer {
     pub tape: Pubkey,
-    // pub state: SegmentTree,
+    pub state: SegmentTree,
 }
 
 impl DataLen for Writer {

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -1,10 +1,10 @@
 use crate::consts::*;
-// use brine_tree::MerkleTree;
+use utils::tree::MerkleTree;
 use bytemuck::{Pod, Zeroable};
 use core::ops::{Deref, Index};
 use pinocchio::program_error::ProgramError;
-// pub type SegmentTree = MerkleTree<{ SEGMENT_TREE_HEIGHT }>;
-// pub type TapeTree = MerkleTree<{ TAPE_TREE_HEIGHT }>;
+pub type SegmentTree = MerkleTree<{ SEGMENT_TREE_HEIGHT }>;
+pub type TapeTree = MerkleTree<{ TAPE_TREE_HEIGHT }>;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]

--- a/program/src/instruction/tape/tape_create.rs
+++ b/program/src/instruction/tape/tape_create.rs
@@ -13,6 +13,7 @@ use {
         consts::{HEADER_SIZE, TAPE, WRITER},
         pda::{tape_pda, writer_pda},
         state::{DataLen, Tape, TapeState, Writer},
+        types::SegmentTree,
     },
 };
 
@@ -128,7 +129,7 @@ pub fn process_tape_create(accounts: &[AccountInfo], data: &[u8]) -> ProgramResu
     let writer = Writer::unpack_mut(&mut writer_info_raw_data)?;
 
     writer.tape = *tape_info.key();
-    // writer.state = *;  # dev : not implemented in Writer layout !
+    writer.state = SegmentTree::new(&[tape_info.key().as_ref()]);
 
     Ok(())
 }

--- a/program/src/instruction/tape/tape_create.rs
+++ b/program/src/instruction/tape/tape_create.rs
@@ -1,5 +1,134 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
+use {
+    crate::{instruction::Create, utils::ByteConversion},
+    bytemuck::Zeroable,
+    pinocchio::{
+        account_info::AccountInfo,
+        instruction::{Seed, Signer},
+        program_error::ProgramError,
+        sysvars::{clock::Clock, rent::Rent, Sysvar},
+        ProgramResult,
+    },
+    pinocchio_system::instructions::CreateAccount,
+    tape_api::{
+        consts::{HEADER_SIZE, TAPE, WRITER},
+        pda::{tape_pda, writer_pda},
+        state::{DataLen, Tape, TapeState, Writer},
+    },
+};
 
 pub fn process_tape_create(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let current_slot = Clock::get()?.slot;
+
+    let args = Create::try_from_bytes(data)?;
+
+    // dev : ignore system_program_info and rent_sysvar_info
+    let [signer_info, tape_info, writer_info, _remaining @ ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    if !signer_info.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    };
+
+    let (tape_address, _tape_bump) = tape_pda(*signer_info.key(), &args.name);
+    let (writer_address, _writer_bump) = writer_pda(tape_address);
+
+    if !tape_info.data_is_empty() {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    };
+
+    if !tape_info.is_writable() {
+        return Err(ProgramError::MissingRequiredSignature);
+    };
+
+    if tape_info.key().ne(&tape_address) {
+        return Err(ProgramError::InvalidAccountData);
+    };
+
+    if !writer_info.data_is_empty() {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    };
+
+    if !writer_info.is_writable() {
+        return Err(ProgramError::MissingRequiredSignature);
+    };
+
+    if writer_info.key().ne(&writer_address) {
+        return Err(ProgramError::InvalidAccountData);
+    };
+
+    //   dev : ignore unnecessary checks
+    //   - system program
+    //   - rent sysvar
+
+    // create tape_info PDA
+    let tape_info_space = Tape::LEN;
+    let tape_info_rent = Rent::get()?.minimum_balance(tape_info_space);
+    let tape_bump_binding = [_tape_bump];
+
+    let tape_info_seeds = &[
+        Seed::from(TAPE),
+        Seed::from(signer_info.key().as_ref()),
+        Seed::from(&args.name),
+        Seed::from(&tape_bump_binding),
+    ];
+
+    let tape_info_signature = Signer::from(tape_info_seeds);
+
+    CreateAccount {
+        from: signer_info,
+        to: tape_info,
+        lamports: tape_info_rent,
+        space: tape_info_space as u64,
+        owner: &tape_api::ID,
+    }
+    .invoke_signed(&[tape_info_signature])?;
+
+    // create writer_info pda
+    let writer_info_space = Writer::LEN;
+    let writer_info_rent = Rent::get()?.minimum_balance(writer_info_space);
+    let writer_bump_binding = [_writer_bump];
+
+    let writer_info_seeds = &[
+        Seed::from(WRITER),
+        Seed::from(tape_info.key().as_ref()),
+        Seed::from(&writer_bump_binding),
+    ];
+
+    let writer_info_signature = Signer::from(writer_info_seeds);
+
+    CreateAccount {
+        from: signer_info,
+        to: writer_info,
+        lamports: writer_info_rent,
+        space: writer_info_space as u64,
+        owner: &tape_api::ID,
+    }
+    .invoke_signed(&[writer_info_signature])?;
+
+    // initialize tape_info data
+    let mut tape_info_raw_data = tape_info.try_borrow_mut_data()?;
+    let tape = Tape::unpack_mut(&mut tape_info_raw_data)?;
+
+    *tape = Tape {
+        number: 0, // (tapes get a number when finalized)
+        authority: *signer_info.key(),
+        name: args.name,
+        state: TapeState::Created as u64,
+        total_segments: 0,
+        merkle_root: [0; 32],
+        header: [0; HEADER_SIZE],
+        first_slot: current_slot,
+        tail_slot: current_slot,
+        ..Tape::zeroed()
+    };
+
+    // initialize writer_info data
+    let mut writer_info_raw_data = writer_info.try_borrow_mut_data()?;
+    let writer = Writer::unpack_mut(&mut writer_info_raw_data)?;
+
+    writer.tape = *tape_info.key();
+    // writer.state = *;  # dev : not implemented in Writer layout !
+
     Ok(())
 }

--- a/program/src/instruction/tape/tape_set_header.rs
+++ b/program/src/instruction/tape/tape_set_header.rs
@@ -1,5 +1,43 @@
-use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
+use {
+    crate::{instruction::SetHeader, utils::ByteConversion},
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    tape_api::{
+        error::TapeError,
+        pda::tape_pda,
+        state::{Tape, TapeState},
+        utils::check_condition,
+    },
+};
 
 pub fn process_tape_set_header(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let args = SetHeader::try_from_bytes(data)?;
+    let [signer_info, tape_info] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    let mut tape_info_raw_data = tape_info.try_borrow_mut_data()?;
+    let tape = Tape::unpack_mut(&mut tape_info_raw_data)?;
+
+    if !signer_info.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    };
+
+    if signer_info.key().ne(&tape.authority) {
+        return Err(ProgramError::MissingRequiredSignature);
+    };
+
+    let (tape_address, _) = tape_pda(*signer_info.key(), &tape.name);
+
+    if tape_info.key().ne(&tape_address) {
+        return Err(ProgramError::InvalidAccountData);
+    };
+
+    check_condition(
+        tape.state.eq(&(u64::from(TapeState::Writing as u8))),
+        TapeError::UnexpectedState,
+    )?;
+
+    tape.header = args.header;
+
     Ok(())
 }

--- a/program/src/state/spool.rs
+++ b/program/src/state/spool.rs
@@ -2,6 +2,7 @@ use crate::state::AccountType;
 use crate::utils::AccountDiscriminator;
 use bytemuck::{Pod, Zeroable};
 use pinocchio::pubkey::Pubkey;
+use tape_api::types::TapeTree;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
@@ -9,7 +10,7 @@ pub struct Spool {
     pub number: u64,
 
     pub authority: Pubkey,
-    // pub state: TapeTree,
+    pub state: TapeTree,
     pub seed: [u8; 32],
     pub contains: [u8; 32],
 

--- a/program/src/state/writer.rs
+++ b/program/src/state/writer.rs
@@ -2,12 +2,13 @@ use crate::state::AccountType;
 use crate::utils::AccountDiscriminator;
 use bytemuck::{Pod, Zeroable};
 use pinocchio::pubkey::Pubkey;
+use tape_api::types::SegmentTree;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 pub struct Writer {
     pub tape: Pubkey,
-    // pub state: SegmentTree,
+    pub state: SegmentTree,
 }
 
 impl AccountDiscriminator for Writer {


### PR DESCRIPTION
### What’s new

- Added complete `tape_create` implementation  
- Added complete `tape_set_header` implementation  
- Resolved local `MerkleTree` dependency in `tape_api::types` and fixed import conflicts in files including:
        -  *api/...[writer , spool]*
        -  *program/...[writer, spool]*

### Notes

- Ensured `writer.state` initialization in `process_tape_create`  
- Verified imports are consistent across modules  
